### PR TITLE
Ensure to include float.h to use DBL_* constants

### DIFF
--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -2,6 +2,7 @@
 #include <ruby/util.h>
 #include <ruby/version.h>
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 
 #if RUBY_API_VERSION_CODE >= 20400


### PR DESCRIPTION
Hello :wave: Long time no see.

Thanks for your simple and easy to use library.  We use this all the time to organize our research data. 

Here is a simple one-line PR to include `<float.h>` to fix [a warning](https://github.com/mrkn/enumerable-statistics/actions/runs/12501742850/job/34879682550#step:7:47): `"DBL_MANT_DIG" is not defined, evaluates to 0 [-Wundef].`
This is because the file [statics.c uses `DBL_MANT_DIG`](https://github.com/mrkn/enumerable-statistics/blob/1d39ac3fb9/ext/enumerable/statistics/extension/statistics.c#L272) but no proper header `<float.h>` included, which is in the standard C.