### PR TITLE
doc: update repository URLs to red-data-tools organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/mrkn/enumerable-statistics.
+Bug reports and pull requests are welcome on GitHub at https://github.com/red-data-tools/enumerable-statistics.
 

--- a/enumerable-statistics.gemspec
+++ b/enumerable-statistics.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Statistics features for Enumerable}
   spec.description   = %q{This library provides statistics features for Enumerable}
-  spec.homepage      = "https://github.com/mrkn/enumerable-statistics"
+  spec.homepage      = "https://github.com/red-data-tools/enumerable-statistics"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
The repository has been moved from mrkn to red-data-tools organization.